### PR TITLE
- feat: Create the API serializers.py-DirectPaymentCreateSerializer /…

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,5 +95,6 @@ FinalProject - House of Today API
     - fix: Add the API serializers.py-ProductOrderCartSerializer // Add the ProductThumnail image One. -> field name : 'image'
     - feat: Create the models.py-DirectPayment // It was added for direct payment.
     - feat: Make Project app - community
+    - feat: Create the API serializers.py-DirectPaymentCreateSerializer // api_views.py-DirectPaymentCreateAPIView, @receiver-after_direct_payment // urls.py-url('payment/direct/') // admin.py-DirectPaymentAdmin // Main content: When a record is added to 'DirectPayment', the record is automatically saved to 'OrderProduct'.
     
     

--- a/products/admin.py
+++ b/products/admin.py
@@ -66,8 +66,8 @@ class DirectPaymentAdmin(admin.ModelAdmin):
 
 # 결제상품목록Admin
 class OrderProductAdmin(admin.ModelAdmin):
-    fields = ['user', 'product_option', 'payment']
-    list_display = ['id', 'user', 'product_option', 'payment', 'created']
+    fields = ['user', 'product_option', 'payment', 'direct_payment']
+    list_display = ['id', 'user', 'product_option', 'payment', 'direct_payment', 'created']
 
 
 admin.site.register(Category, CategoryAdmin)

--- a/products/serializers.py
+++ b/products/serializers.py
@@ -1,4 +1,3 @@
-from django.db.models import Avg, Count, F, Sum, Case, When
 from rest_framework import serializers
 from rest_framework.fields import SerializerMethodField
 
@@ -9,13 +8,6 @@ class ThumnailImageSerializer(serializers.ModelSerializer):
     class Meta:
         model = ProductThumnail
         fields = '__all__'
-
-
-# 장바구니에서 이미지 url만 추출하기 위한 용도
-# class ThumnailImageURLSerializer(serializers.ModelSerializer):
-#     class Meta:
-#         model = ProductThumnail
-#         fields = ['image']
 
 
 class DetailImageSerializer(serializers.ModelSerializer):
@@ -126,9 +118,6 @@ class ProductOrderCartCreateSerializer(serializers.ModelSerializer):
 
 # GET - 장바구니
 # source 관련 참조 : https://stackoverflow.com/questions/32166826/django-rest-framework-how-to-get-field-of-foreign-key-of-a-foreign-key
-
-# 쿼리 쓰던가 meta쓰던
-
 class ProductOrderCartSerializer(serializers.ModelSerializer):
     brand_name = serializers.CharField(source='product_option.product.brand_name')
     product = serializers.CharField(source='product_option.product.name')
@@ -170,10 +159,17 @@ class OrderProductSerializer(serializers.ModelSerializer):
         fields = ['product', 'product_option']
 
 
-# POST - 결제하기
+# POST - 결제하기(장바구니 이용)
 class PaymentCreateSerializer(serializers.ModelSerializer):
     class Meta:
         model = Payment
+        exclude = ['user']
+
+
+# POST - 바로결제하기(장바구니 없이 직접)
+class DirectPaymentCreateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = DirectPayment
         exclude = ['user']
 
 

--- a/products/urls.py
+++ b/products/urls.py
@@ -24,10 +24,8 @@ urlpatterns = [
 
     # 주문/결제 생성 - 장바구니 이용
     path('payment/', PaymentCreateAPIView.as_view()),
-
     # 주문/결제 생성 - [결제하기] 버튼을 통한 장바구니 없이 결제하기.
-    # path('payment/direct/', ),
-
+    path('payment/direct/', DirectPaymentCreateAPIView.as_view()),
     # 결제 완료된 목록
     path('payment/list/', PaymentAPIView.as_view()),
 


### PR DESCRIPTION
- feat: Create the API serializers.py-DirectPaymentCreateSerializer // api_views.py-DirectPaymentCreateAPIView, @receiver-after_direct_payment // urls.py-url('payment/direct/') // admin.py-DirectPaymentAdmin // Main content: When a record is added to 'DirectPayment', the record is automatically saved to 'OrderProduct'.

Please Check it.